### PR TITLE
0.2.7 release

### DIFF
--- a/dns/dyndnsgd/CHANGELOG.md
+++ b/dns/dyndnsgd/CHANGELOG.md
@@ -5,15 +5,16 @@ All notable changes to this project will be documented in this file.
 
 ### KNOWN ISSUES
 
-- Backend is not yet supported.
-- Logging is not yet supported.
-
 ### Added
+
+None
 
 ### Changed
 
 ### Fixed
 
+None
+    
 ## 0.2.7 [Unreleased] - yyyy-mm-dd
 
 ### KNOWN ISSUES
@@ -23,9 +24,22 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+N/A
+
 ### Changed
 
-- Remove edit buttons from both views (Account, Domains)
+Remove Edit-buttons from both views (Account, Domains)
+
+Account dialog :
+- Command buttons for Edit and Delete actions added for account row
+- Delete button from bottom of grid was removed.
+- Tooltip was added to the Add-button.
+- Added data formatter to the Staging-column.
+
+Domain dialog :
+- Command buttons for Edit and Delete actions added for account row
+- Delete button from bottom of grid was removed.
+- Tooltip was added to the Add-button.
 
 ### Fixed
 

--- a/dns/dyndnsgd/CHANGELOG.md
+++ b/dns/dyndnsgd/CHANGELOG.md
@@ -15,7 +15,7 @@ None
 
 None
     
-## 0.2.7 [Unreleased] - yyyy-mm-dd
+## 0.2.7 [released] - 2021-05-29
 
 ### KNOWN ISSUES
 

--- a/dns/dyndnsgd/src/opnsense/mvc/app/models/OPNsense/DynDNSGD/Domains.xml
+++ b/dns/dyndnsgd/src/opnsense/mvc/app/models/OPNsense/DynDNSGD/Domains.xml
@@ -18,11 +18,18 @@
                     <default></default>
                     <Required>Y</Required>
                 </domain>
-                <account type="OptionField">
-                    <default>GoDaddy</default>
-                    <OptionValues>
-                        <auto>GoDaddy</auto>
-                    </OptionValues>
+                <account type="ModelRelationField">
+                    <Model>
+                        <accounts>
+                            <source>OPNsense.DynDNSGD.Accounts</source>
+                            <items>accounts.account</items>
+                            <display>name</display>
+                            <filters>
+                                <enabled>/^(?!0).*$/</enabled>
+                            </filters>
+                        </accounts>
+                    </Model>
+                    <multiple>N</multiple>
                     <Required>Y</Required>
                 </account>
                 <interface type="InterfaceField">


### PR DESCRIPTION
Changed:

Remove Edit-buttons from both views (Account, Domains)

Account dialog :
- Command buttons for Edit and Delete actions added for account row
- Delete button from bottom of grid was removed.
- Tooltip was added to the Add-button.
- Added data formatter to the Staging-column.

Domain dialog :
- Command buttons for Edit and Delete actions added for account row
- Delete button from bottom of grid was removed.
- Tooltip was added to the Add-button.
